### PR TITLE
use fork instead of owner when creating blob

### DIFF
--- a/src/create-tree.ts
+++ b/src/create-tree.ts
@@ -75,10 +75,10 @@ export async function createTree(
           }
 
           if (result === null || typeof result === "undefined") return;
-          return valueToTreeObject(octokit, owner, repo, path, result);
+          return valueToTreeObject(octokit, fork, repo, path, result);
         }
 
-        return valueToTreeObject(octokit, owner, repo, path, value);
+        return valueToTreeObject(octokit, fork, repo, path, value);
       })
     )
   ).filter(Boolean) as TreeParameter;


### PR DESCRIPTION
When creating a commit with binary files (e.g. images) on a fork, we incorrectly try to create the tree in the original repo.