### PR TITLE
add force fork for easier testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ octokit
     body: "pull request description",
     base: "main" /* optional: defaults to default branch */,
     head: "pull-request-branch-name",
-    forceFork: false, /* optional: force creating fork even when user has write rights */
+    forceFork: false, /* optional: force creating fork even when user has write rights */,
     changes: [
       {
         /* optional: if `files` is not passed, an empty commit is created instead */

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ octokit
     body: "pull request description",
     base: "main" /* optional: defaults to default branch */,
     head: "pull-request-branch-name",
+    forceFork: false, /* optional: force creating fork even when user has write rights */
     changes: [
       {
         /* optional: if `files` is not passed, an empty commit is created instead */

--- a/src/compose-create-pull-request.ts
+++ b/src/compose-create-pull-request.ts
@@ -16,6 +16,7 @@ export async function composeCreatePullRequest(
     createWhenEmpty,
     changes: changesOption,
     draft = false,
+    forceFork = false,
   }: Options
 ) {
   const changes = Array.isArray(changesOption)
@@ -52,7 +53,7 @@ export async function composeCreatePullRequest(
 
   state.fork = owner;
 
-  if (isUser && !repository.permissions.push) {
+  if (forceFork || (isUser && !repository.permissions.push)) {
     // https://developer.github.com/v3/users/#get-the-authenticated-user
     const user = await octokit.request("GET /user");
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export type Options = {
   createWhenEmpty?: boolean;
   changes: Changes | Changes[];
   draft?: boolean;
+  forceFork?: boolean;
 };
 
 export type Changes = {


### PR DESCRIPTION
Additional flag to always fork. This is particularly useful when testing forked repositories or to always force the experience of a non-member in a project taking PR using the package.