### PR TITLE
fork with binary files

### DIFF
--- a/src/compose-create-pull-request.ts
+++ b/src/compose-create-pull-request.ts
@@ -81,7 +81,7 @@ export async function composeCreatePullRequest(
   const {
     data: [latestCommit],
   } = await octokit.request("GET /repos/{owner}/{repo}/commits", {
-    owner,
+    owner: state.fork,
     repo,
     sha: base,
     per_page: 1,


### PR DESCRIPTION
This fix uses the fork head commit instead of the upstream commit when creating the PR tree. A number of tests fail as a result but I'm unsure whether that's expected or something broke.

Tested here:
https://github.com/microsoft/jacdac/pull/932
