### PR TITLE
Use graphql to search for existing pull request

### DIFF
--- a/src/compose-create-pull-request.ts
+++ b/src/compose-create-pull-request.ts
@@ -159,9 +159,9 @@ export async function composeCreatePullRequest(
     }
   );
 
-  const branchExists = !!branchInfo.repository?.ref;
+  const branchExists = !!branchInfo.repository.ref;
   const existingPullRequest =
-    branchInfo.repository?.ref?.associatedPullRequests?.edges?.[0]?.node;
+    branchInfo.repository.ref?.associatedPullRequests?.edges?.[0]?.node;
 
   if (existingPullRequest && !update) {
     throw new Error(

--- a/src/compose-create-pull-request.ts
+++ b/src/compose-create-pull-request.ts
@@ -127,16 +127,16 @@ export async function composeCreatePullRequest(
           edges: [
             {
               node: {
-                url: string,
-                number: number,
-              }
+                url: string;
+                number: number;
+              };
             }
-          ]
-        }
-      }
-    }
-  } = await octokit
-    .graphql(`
+          ];
+        };
+      };
+    };
+  } = await octokit.graphql(
+    `
     query ($owner: String!, $repo: String!, $head: String!) {
       repository(name: $repo, owner: $owner) {
         ref(qualifiedName: $head) {
@@ -151,14 +151,17 @@ export async function composeCreatePullRequest(
           }
         }
       }
-    }`, {
+    }`,
+    {
       owner,
       repo,
       head,
-    })
+    }
+  );
 
-  const branchExists = !!branchInfo.repository?.ref
-  const existingPullRequest = branchInfo.repository?.ref?.associatedPullRequests?.edges?.[0]?.node
+  const branchExists = !!branchInfo.repository?.ref;
+  const existingPullRequest =
+    branchInfo.repository?.ref?.associatedPullRequests?.edges?.[0]?.node;
 
   if (existingPullRequest && !update) {
     throw new Error(

--- a/src/compose-create-pull-request.ts
+++ b/src/compose-create-pull-request.ts
@@ -120,35 +120,49 @@ export async function composeCreatePullRequest(
     return null;
   }
 
-  // https://docs.github.com/en/rest/git/refs#get-a-reference
-  const branchExists = await octokit
-    .request("GET /repos/{owner}/{repo}/git/ref/{ref}", {
-      owner: state.fork,
-      repo,
-      ref: `heads/${head}`,
-    })
-    .then(
-      () => true,
-      (error) => {
-        /* istanbul ignore else */
-        if (error.status === 404) return false;
-
-        /* istanbul ignore next */
-        throw error;
+  const branchInfo: {
+    repository: {
+      ref: {
+        associatedPullRequests: {
+          edges: [
+            {
+              node: {
+                url: string,
+                number: number,
+              }
+            }
+          ]
+        }
       }
-    );
+    }
+  } = await octokit
+    .graphql(`
+    query ($owner: String!, $repo: String!, $head: String!) {
+      repository(name: $repo, owner: $owner) {
+        ref(qualifiedName: $head) {
+          associatedPullRequests(first: 1, states: OPEN) {
+            edges {
+              node {
+                id
+                number
+                url
+              }
+            }
+          }
+        }
+      }
+    }`, {
+      owner,
+      repo,
+      head,
+    })
 
-  const existingPullRequest = branchExists
-    ? await octokit
-        .request("GET /search/issues", {
-          q: `head:${head} type:pr is:open repo:${owner}/${repo}`,
-        })
-        .then((response) => response.data.items[0])
-    : undefined;
+  const branchExists = !!branchInfo.repository?.ref
+  const existingPullRequest = branchInfo.repository?.ref?.associatedPullRequests?.edges?.[0]?.node
 
   if (existingPullRequest && !update) {
     throw new Error(
-      `[octokit-plugin-create-pull-request] Pull request already exists: ${existingPullRequest.html_url}. Set update=true to enable updating`
+      `[octokit-plugin-create-pull-request] Pull request already exists: ${existingPullRequest.url}. Set update=true to enable updating`
     );
   }
 

--- a/test/fixtures/create-binary-file.json
+++ b/test/fixtures/create-binary-file.json
@@ -563,7 +563,7 @@
   },
   {
     "request": {
-      "method": "GET",
+      "method": "POST",
       "baseUrl": "https://api.github.com",
       "headers": {
         "accept": "application/vnd.github.v3+json",
@@ -574,13 +574,16 @@
         "previews": []
       },
       "request": {},
-      "url": "/repos/{owner}/{repo}/git/ref/{ref}",
-      "owner": "gr2m",
-      "repo": "pull-request-test",
-      "ref": "heads/patch"
+      "url": "/graphql",
+      "query": "\n    query ($owner: String!, $repo: String!, $head: String!) {\n      repository(name: $repo, owner: $owner) {\n        ref(qualifiedName: $head) {\n          associatedPullRequests(first: 1, states: OPEN) {\n            edges {\n              node {\n                id\n                number\n                url\n              }\n            }\n          }\n        }\n      }\n    }",
+      "variables": {
+        "owner": "gr2m",
+        "repo": "pull-request-test",
+        "head": "patch"
+      }
     },
     "response": {
-      "status": 404,
+      "status": 200,
       "headers": {
         "access-control-allow-origin": "*",
         "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset",
@@ -612,8 +615,11 @@
         "x-xss-protection": "0"
       },
       "data": {
-        "error": "Not Found",
-        "documentation_url": "https://docs.github.com/rest/reference/git#get-a-reference"
+        "data": {
+          "repository": {
+            "ref": null
+          }
+        }
       }
     }
   },

--- a/test/fixtures/create-fork.json
+++ b/test/fixtures/create-fork.json
@@ -1087,7 +1087,7 @@
   },
   {
     "request": {
-      "method": "GET",
+      "method": "POST",
       "baseUrl": "https://api.github.com",
       "headers": {
         "accept": "application/vnd.github.v3+json",
@@ -1098,13 +1098,16 @@
         "previews": []
       },
       "request": {},
-      "url": "/repos/{owner}/{repo}/git/ref/{ref}",
-      "owner": "gr2m-test",
-      "repo": "pull-request-test",
-      "ref": "heads/test-branch-u7es0"
+      "url": "/graphql",
+      "query": "\n    query ($owner: String!, $repo: String!, $head: String!) {\n      repository(name: $repo, owner: $owner) {\n        ref(qualifiedName: $head) {\n          associatedPullRequests(first: 1, states: OPEN) {\n            edges {\n              node {\n                id\n                number\n                url\n              }\n            }\n          }\n        }\n      }\n    }",
+      "variables": {
+        "owner": "gr2m",
+        "repo": "pull-request-test",
+        "head": "test-branch-u7es0"
+      }
     },
     "response": {
-      "status": 404,
+      "status": 200,
       "headers": {
         "access-control-allow-origin": "*",
         "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset",
@@ -1134,8 +1137,11 @@
         "x-xss-protection": "0"
       },
       "data": {
-        "error": "Not Found",
-        "documentation_url": "https://docs.github.com/rest/reference/git#get-a-reference"
+        "data": {
+          "repository": {
+            "ref": null
+          }
+        }
       }
     }
   },

--- a/test/fixtures/custom-base.json
+++ b/test/fixtures/custom-base.json
@@ -509,7 +509,7 @@
   },
   {
     "request": {
-      "method": "GET",
+      "method": "POST",
       "baseUrl": "https://api.github.com",
       "headers": {
         "accept": "application/vnd.github.v3+json",
@@ -520,13 +520,16 @@
         "previews": []
       },
       "request": {},
-      "url": "/repos/{owner}/{repo}/git/ref/{ref}",
-      "owner": "gr2m",
-      "repo": "pull-request-test",
-      "ref": "heads/test-branch-1rtg5"
+      "url": "/graphql",
+      "query": "\n    query ($owner: String!, $repo: String!, $head: String!) {\n      repository(name: $repo, owner: $owner) {\n        ref(qualifiedName: $head) {\n          associatedPullRequests(first: 1, states: OPEN) {\n            edges {\n              node {\n                id\n                number\n                url\n              }\n            }\n          }\n        }\n      }\n    }",
+      "variables": {
+        "owner": "gr2m",
+        "repo": "pull-request-test",
+        "head": "test-branch-1rtg5"
+      }
     },
     "response": {
-      "status": 404,
+      "status": 200,
       "headers": {
         "access-control-allow-origin": "*",
         "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset",
@@ -558,8 +561,11 @@
         "x-xss-protection": "0"
       },
       "data": {
-        "error": "Not Found",
-        "documentation_url": "https://docs.github.com/rest/reference/git#get-a-reference"
+        "data": {
+          "repository": {
+            "ref": null
+          }
+        }
       }
     }
   },

--- a/test/fixtures/delete-files.json
+++ b/test/fixtures/delete-files.json
@@ -618,7 +618,7 @@
   },
   {
     "request": {
-      "method": "GET",
+      "method": "POST",
       "baseUrl": "https://api.github.com",
       "headers": {
         "accept": "application/vnd.github.v3+json",
@@ -629,13 +629,16 @@
         "previews": []
       },
       "request": {},
-      "url": "/repos/{owner}/{repo}/git/ref/{ref}",
-      "owner": "gr2m",
-      "repo": "pull-request-test",
-      "ref": "heads/patch"
+      "url": "/graphql",
+      "query": "\n    query ($owner: String!, $repo: String!, $head: String!) {\n      repository(name: $repo, owner: $owner) {\n        ref(qualifiedName: $head) {\n          associatedPullRequests(first: 1, states: OPEN) {\n            edges {\n              node {\n                id\n                number\n                url\n              }\n            }\n          }\n        }\n      }\n    }",
+      "variables": {
+        "owner": "gr2m",
+        "repo": "pull-request-test",
+        "head": "patch"
+      }
     },
     "response": {
-      "status": 404,
+      "status": 200,
       "headers": {
         "access-control-allow-origin": "*",
         "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset",
@@ -667,8 +670,11 @@
         "x-xss-protection": "0"
       },
       "data": {
-        "error": "Not Found",
-        "documentation_url": "https://docs.github.com/rest/reference/git#get-a-reference"
+        "data": {
+          "repository": {
+            "ref": null
+          }
+        }
       }
     }
   },

--- a/test/fixtures/empty-commit-message.json
+++ b/test/fixtures/empty-commit-message.json
@@ -677,7 +677,7 @@
   },
   {
     "request": {
-      "method": "GET",
+      "method": "POST",
       "baseUrl": "https://api.github.com",
       "headers": {
         "accept": "application/vnd.github.v3+json",
@@ -688,13 +688,16 @@
         "previews": []
       },
       "request": {},
-      "url": "/repos/{owner}/{repo}/git/ref/{ref}",
-      "owner": "gr2m",
-      "repo": "pull-request-test",
-      "ref": "heads/empty-commit-message"
+      "url": "/graphql",
+      "query": "\n    query ($owner: String!, $repo: String!, $head: String!) {\n      repository(name: $repo, owner: $owner) {\n        ref(qualifiedName: $head) {\n          associatedPullRequests(first: 1, states: OPEN) {\n            edges {\n              node {\n                id\n                number\n                url\n              }\n            }\n          }\n        }\n      }\n    }",
+      "variables": {
+        "owner": "gr2m",
+        "repo": "pull-request-test",
+        "head": "empty-commit-message"
+      }
     },
     "response": {
-      "status": 404,
+      "status": 200,
       "headers": {
         "access-control-allow-origin": "*",
         "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset",
@@ -726,8 +729,11 @@
         "x-xss-protection": "0"
       },
       "data": {
-        "error": "Not Found",
-        "documentation_url": "https://docs.github.com/rest/reference/git#get-a-reference"
+        "data": {
+          "repository": {
+            "ref": null
+          }
+        }
       }
     }
   },

--- a/test/fixtures/empty-commits.json
+++ b/test/fixtures/empty-commits.json
@@ -488,7 +488,7 @@
   },
   {
     "request": {
-      "method": "GET",
+      "method": "POST",
       "baseUrl": "https://api.github.com",
       "headers": {
         "accept": "application/vnd.github.v3+json",
@@ -499,13 +499,16 @@
         "previews": []
       },
       "request": {},
-      "url": "/repos/{owner}/{repo}/git/ref/{ref}",
-      "owner": "gr2m",
-      "repo": "pull-request-test",
-      "ref": "heads/empty-files"
+      "url": "/graphql",
+      "query": "\n    query ($owner: String!, $repo: String!, $head: String!) {\n      repository(name: $repo, owner: $owner) {\n        ref(qualifiedName: $head) {\n          associatedPullRequests(first: 1, states: OPEN) {\n            edges {\n              node {\n                id\n                number\n                url\n              }\n            }\n          }\n        }\n      }\n    }",
+      "variables": {
+        "owner": "gr2m",
+        "repo": "pull-request-test",
+        "head": "empty-files"
+      }
     },
     "response": {
-      "status": 404,
+      "status": 200,
       "headers": {
         "access-control-allow-origin": "*",
         "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset",
@@ -537,8 +540,11 @@
         "x-xss-protection": "0"
       },
       "data": {
-        "error": "Not Found",
-        "documentation_url": "https://docs.github.com/rest/reference/git#get-a-reference"
+        "data": {
+          "repository": {
+            "ref": null
+          }
+        }
       }
     }
   },

--- a/test/fixtures/empty-update.json
+++ b/test/fixtures/empty-update.json
@@ -473,7 +473,7 @@
   },
   {
     "request": {
-      "method": "GET",
+      "method": "POST",
       "baseUrl": "https://api.github.com",
       "headers": {
         "accept": "application/vnd.github.v3+json",
@@ -484,13 +484,17 @@
         "previews": []
       },
       "request": {},
-      "url": "/repos/{owner}/{repo}/git/ref/{ref}",
-      "owner": "gr2m",
-      "repo": "pull-request-test",
-      "ref": "heads/empty-update"
+      "url": "/graphql",
+      "query": "\n    query ($owner: String!, $repo: String!, $head: String!) {\n      repository(name: $repo, owner: $owner) {\n        ref(qualifiedName: $head) {\n          associatedPullRequests(first: 1, states: OPEN) {\n            edges {\n              node {\n                id\n                number\n                url\n              }\n            }\n          }\n        }\n      }\n    }",
+      "variables": {
+        "owner": "gr2m",
+        "repo": "pull-request-test",
+        "head": "empty-update"
+      }
     },
     "response": {
-      "status": 404,
+      "status": 200,
+      "url": "https://api.github.com/graphql",
       "headers": {
         "access-control-allow-origin": "*",
         "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset",
@@ -522,8 +526,11 @@
         "x-xss-protection": "0"
       },
       "data": {
-        "error": "Not Found",
-        "documentation_url": "https://docs.github.com/rest/reference/git#get-a-reference"
+        "data": {
+          "repository": {
+            "ref": null
+          }
+        }
       }
     }
   },

--- a/test/fixtures/happy-path-with-mode.json
+++ b/test/fixtures/happy-path-with-mode.json
@@ -569,7 +569,7 @@
   },
   {
     "request": {
-      "method": "GET",
+      "method": "POST",
       "baseUrl": "https://api.github.com",
       "headers": {
         "accept": "application/vnd.github.v3+json",
@@ -580,13 +580,17 @@
         "previews": []
       },
       "request": {},
-      "url": "/repos/{owner}/{repo}/git/ref/{ref}",
-      "owner": "gr2m",
-      "repo": "pull-request-test",
-      "ref": "heads/happy-path-with-mode"
+      "url": "/graphql",
+      "query": "\n    query ($owner: String!, $repo: String!, $head: String!) {\n      repository(name: $repo, owner: $owner) {\n        ref(qualifiedName: $head) {\n          associatedPullRequests(first: 1, states: OPEN) {\n            edges {\n              node {\n                id\n                number\n                url\n              }\n            }\n          }\n        }\n      }\n    }",
+      "variables": {
+        "owner": "gr2m",
+        "repo": "pull-request-test",
+        "head": "happy-path-with-mode"
+      }
     },
     "response": {
-      "status": 404,
+      "status": 200,
+      "url": "https://api.github.com/graphql",
       "headers": {
         "access-control-allow-origin": "*",
         "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset",
@@ -611,15 +615,18 @@
         "x-oauth-scopes": "notifications, repo, workflow, write:org",
         "x-poll-interval": "300",
         "x-ratelimit-limit": "5000",
-        "x-ratelimit-remaining": "4945",
-        "x-ratelimit-reset": "1656378677",
-        "x-ratelimit-resource": "core",
-        "x-ratelimit-used": "55",
+        "x-ratelimit-remaining": "4992",
+        "x-ratelimit-reset": "1661368387",
+        "x-ratelimit-resource": "graphql",
+        "x-ratelimit-used": "8",
         "x-xss-protection": "0"
       },
       "data": {
-        "error": "Not Found",
-        "documentation_url": "https://docs.github.com/rest/reference/git#get-a-reference"
+        "data": {
+          "repository": {
+            "ref": null
+          }
+        }
       }
     }
   },

--- a/test/fixtures/happy-path.json
+++ b/test/fixtures/happy-path.json
@@ -509,7 +509,7 @@
   },
   {
     "request": {
-      "method": "GET",
+      "method": "POST",
       "baseUrl": "https://api.github.com",
       "headers": {
         "accept": "application/vnd.github.v3+json",
@@ -520,13 +520,16 @@
         "previews": []
       },
       "request": {},
-      "url": "/repos/{owner}/{repo}/git/ref/{ref}",
-      "owner": "gr2m",
-      "repo": "pull-request-test",
-      "ref": "heads/happy-path"
+      "url": "/graphql",
+      "query": "\n    query ($owner: String!, $repo: String!, $head: String!) {\n      repository(name: $repo, owner: $owner) {\n        ref(qualifiedName: $head) {\n          associatedPullRequests(first: 1, states: OPEN) {\n            edges {\n              node {\n                id\n                number\n                url\n              }\n            }\n          }\n        }\n      }\n    }",
+      "variables": {
+        "owner": "gr2m",
+        "repo": "pull-request-test",
+        "head": "happy-path"
+      }
     },
     "response": {
-      "status": 404,
+      "status": 200,
       "headers": {
         "access-control-allow-origin": "*",
         "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset",
@@ -558,8 +561,11 @@
         "x-xss-protection": "0"
       },
       "data": {
-        "error": "Not Found",
-        "documentation_url": "https://docs.github.com/rest/reference/git#get-a-reference"
+        "data": {
+          "repository": {
+            "ref": null
+          }
+        }
       }
     }
   },

--- a/test/fixtures/multiple-commits.json
+++ b/test/fixtures/multiple-commits.json
@@ -724,7 +724,7 @@
   },
   {
     "request": {
-      "method": "GET",
+      "method": "POST",
       "baseUrl": "https://api.github.com",
       "headers": {
         "accept": "application/vnd.github.v3+json",
@@ -735,13 +735,16 @@
         "previews": []
       },
       "request": {},
-      "url": "/repos/{owner}/{repo}/git/ref/{ref}",
-      "owner": "gr2m",
-      "repo": "pull-request-test",
-      "ref": "heads/multiple-commits"
+      "url": "/graphql",
+      "query": "\n    query ($owner: String!, $repo: String!, $head: String!) {\n      repository(name: $repo, owner: $owner) {\n        ref(qualifiedName: $head) {\n          associatedPullRequests(first: 1, states: OPEN) {\n            edges {\n              node {\n                id\n                number\n                url\n              }\n            }\n          }\n        }\n      }\n    }",
+      "variables": {
+        "owner": "gr2m",
+        "repo": "pull-request-test",
+        "head": "multiple-commits"
+      }
     },
     "response": {
-      "status": 404,
+      "status": 200,
       "headers": {
         "access-control-allow-origin": "*",
         "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset",
@@ -773,8 +776,11 @@
         "x-xss-protection": "0"
       },
       "data": {
-        "error": "Not Found",
-        "documentation_url": "https://docs.github.com/rest/reference/git#get-a-reference"
+        "data": {
+          "repository": {
+            "ref": null
+          }
+        }
       }
     }
   },

--- a/test/fixtures/no-empty-commit.json
+++ b/test/fixtures/no-empty-commit.json
@@ -587,7 +587,7 @@
   },
   {
     "request": {
-      "method": "GET",
+      "method": "POST",
       "baseUrl": "https://api.github.com",
       "headers": {
         "accept": "application/vnd.github.v3+json",
@@ -598,13 +598,16 @@
         "previews": []
       },
       "request": {},
-      "url": "/repos/{owner}/{repo}/git/ref/{ref}",
-      "owner": "gr2m",
-      "repo": "pull-request-test",
-      "ref": "heads/no-empty-commits"
+      "url": "/graphql",
+      "query": "\n    query ($owner: String!, $repo: String!, $head: String!) {\n      repository(name: $repo, owner: $owner) {\n        ref(qualifiedName: $head) {\n          associatedPullRequests(first: 1, states: OPEN) {\n            edges {\n              node {\n                id\n                number\n                url\n              }\n            }\n          }\n        }\n      }\n    }",
+      "variables": {
+        "owner": "gr2m",
+        "repo": "pull-request-test",
+        "head": "no-empty-commits"
+      }
     },
     "response": {
-      "status": 404,
+      "status": 200,
       "headers": {
         "access-control-allow-origin": "*",
         "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset",
@@ -636,8 +639,11 @@
         "x-xss-protection": "0"
       },
       "data": {
-        "error": "Not Found",
-        "documentation_url": "https://docs.github.com/rest/reference/git#get-a-reference"
+        "data": {
+          "repository": {
+            "ref": null
+          }
+        }
       }
     }
   },

--- a/test/fixtures/pull-request-exists.json
+++ b/test/fixtures/pull-request-exists.json
@@ -512,7 +512,7 @@
   },
   {
     "request": {
-      "method": "GET",
+      "method": "POST",
       "baseUrl": "https://api.github.com",
       "headers": {
         "accept": "application/vnd.github.v3+json",
@@ -523,10 +523,13 @@
         "previews": []
       },
       "request": {},
-      "url": "/repos/{owner}/{repo}/git/ref/{ref}",
-      "owner": "gr2m",
-      "repo": "pull-request-test",
-      "ref": "heads/pull-request-exists"
+      "url": "/graphql",
+      "query": "\n    query ($owner: String!, $repo: String!, $head: String!) {\n      repository(name: $repo, owner: $owner) {\n        ref(qualifiedName: $head) {\n          associatedPullRequests(first: 1, states: OPEN) {\n            edges {\n              node {\n                id\n                number\n                url\n              }\n            }\n          }\n        }\n      }\n    }",
+      "variables": {
+        "owner": "gr2m",
+        "repo": "pull-request-test",
+        "head": "pull-request-exists"
+      }
     },
     "response": {
       "status": 200,
@@ -565,140 +568,22 @@
         "x-xss-protection": "0"
       },
       "data": {
-        "ref": "refs/heads/pull-request-exists",
-        "node_id": "MDM6UmVmMTYwOTg3NDkyOnJlZnMvaGVhZHMvcHVsbC1yZXF1ZXN0LWV4aXN0cw==",
-        "url": "https://api.github.com/repos/gr2m/pull-request-test/git/refs/heads/pull-request-exists",
-        "object": {
-          "sha": "9a733d9242b58e9954a0e295aff58c8d9721a8b4",
-          "type": "commit",
-          "url": "https://api.github.com/repos/gr2m/pull-request-test/git/commits/9a733d9242b58e9954a0e295aff58c8d9721a8b4"
-        }
-      }
-    }
-  },
-  {
-    "request": {
-      "method": "GET",
-      "baseUrl": "https://api.github.com",
-      "headers": {
-        "accept": "application/vnd.github.v3+json",
-        "user-agent": "octokit-core.js/3.2.5 Node.js/18.3.0 (darwin; arm64)"
-      },
-      "mediaType": {
-        "format": "",
-        "previews": []
-      },
-      "request": {},
-      "url": "/search/issues",
-      "q": "head:pull-request-exists type:pr is:open repo:gr2m/pull-request-test"
-    },
-    "response": {
-      "status": 200,
-      "url": "https://api.github.com/search/issues?q=head%3Apull-request-exists%20type%3Apr%20is%3Aopen%20repo%3Agr2m%2Fpull-request-test",
-      "headers": {
-        "access-control-allow-origin": "*",
-        "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset",
-        "cache-control": "no-cache",
-        "connection": "close",
-        "content-encoding": "gzip",
-        "content-security-policy": "default-src 'none'",
-        "content-type": "application/json; charset=utf-8",
-        "date": "Tue, 28 Jun 2022 00:48:49 GMT",
-        "github-authentication-token-expiration": "2022-08-24 23:46:54 UTC",
-        "referrer-policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
-        "server": "GitHub.com",
-        "strict-transport-security": "max-age=31536000; includeSubdomains; preload",
-        "transfer-encoding": "chunked",
-        "vary": "Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept, X-Requested-With",
-        "x-accepted-oauth-scopes": "",
-        "x-content-type-options": "nosniff",
-        "x-frame-options": "deny",
-        "x-github-api-version-selected": "",
-        "x-github-api-version-selected-reason": "unavailable",
-        "x-github-media-type": "github.v3; format=json",
-        "x-github-request-id": "D5FE:2D3D:A04899:A745DE:62BA4FF1",
-        "x-oauth-scopes": "notifications, repo, workflow, write:org",
-        "x-ratelimit-limit": "30",
-        "x-ratelimit-remaining": "28",
-        "x-ratelimit-reset": "1656377349",
-        "x-ratelimit-resource": "search",
-        "x-ratelimit-used": "2",
-        "x-xss-protection": "0"
-      },
-      "data": {
-        "total_count": 1,
-        "incomplete_results": false,
-        "items": [
-          {
-            "url": "https://api.github.com/repos/gr2m/pull-request-test/issues/99",
-            "repository_url": "https://api.github.com/repos/gr2m/pull-request-test",
-            "labels_url": "https://api.github.com/repos/gr2m/pull-request-test/issues/99/labels{/name}",
-            "comments_url": "https://api.github.com/repos/gr2m/pull-request-test/issues/99/comments",
-            "events_url": "https://api.github.com/repos/gr2m/pull-request-test/issues/99/events",
-            "html_url": "https://github.com/gr2m/pull-request-test/pull/99",
-            "id": 1286615500,
-            "node_id": "PR_kwDOCZh5ZM46dXtQ",
-            "number": 99,
-            "title": "One comes, one goes",
-            "user": {
-              "login": "gr2m",
-              "id": 39992,
-              "node_id": "MDQ6VXNlcjM5OTky",
-              "avatar_url": "https://avatars.githubusercontent.com/u/39992?v=4",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/gr2m",
-              "html_url": "https://github.com/gr2m",
-              "followers_url": "https://api.github.com/users/gr2m/followers",
-              "following_url": "https://api.github.com/users/gr2m/following{/other_user}",
-              "gists_url": "https://api.github.com/users/gr2m/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/gr2m/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/gr2m/subscriptions",
-              "organizations_url": "https://api.github.com/users/gr2m/orgs",
-              "repos_url": "https://api.github.com/users/gr2m/repos",
-              "events_url": "https://api.github.com/users/gr2m/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/gr2m/received_events",
-              "type": "User",
-              "site_admin": true
-            },
-            "labels": [],
-            "state": "open",
-            "locked": false,
-            "assignee": null,
-            "assignees": [],
-            "milestone": null,
-            "comments": 0,
-            "created_at": "2022-06-28T00:47:58Z",
-            "updated_at": "2022-06-28T00:47:58Z",
-            "closed_at": null,
-            "author_association": "OWNER",
-            "active_lock_reason": null,
-            "draft": false,
-            "pull_request": {
-              "url": "https://api.github.com/repos/gr2m/pull-request-test/pulls/99",
-              "html_url": "https://github.com/gr2m/pull-request-test/pull/99",
-              "diff_url": "https://github.com/gr2m/pull-request-test/pull/99.diff",
-              "patch_url": "https://github.com/gr2m/pull-request-test/pull/99.patch",
-              "merged_at": null
-            },
-            "body": "because",
-            "reactions": {
-              "url": "https://api.github.com/repos/gr2m/pull-request-test/issues/99/reactions",
-              "total_count": 0,
-              "+1": 0,
-              "-1": 0,
-              "laugh": 0,
-              "hooray": 0,
-              "confused": 0,
-              "heart": 0,
-              "rocket": 0,
-              "eyes": 0
-            },
-            "timeline_url": "https://api.github.com/repos/gr2m/pull-request-test/issues/99/timeline",
-            "performed_via_github_app": null,
-            "state_reason": null,
-            "score": 1
+        "data": {
+          "repository": {
+            "ref": {
+              "associatedPullRequests": {
+                "edges": [
+                  {
+                    "node": {
+                      "url": "https://github.com/gr2m/pull-request-test/pull/99",
+                      "number": 99
+                    }
+                  }
+                ]
+              }
+            }
           }
-        ]
+        }
       }
     }
   }

--- a/test/fixtures/update-existing-pull-request.json
+++ b/test/fixtures/update-existing-pull-request.json
@@ -512,7 +512,7 @@
   },
   {
     "request": {
-      "method": "GET",
+      "method": "POST",
       "baseUrl": "https://api.github.com",
       "headers": {
         "accept": "application/vnd.github.v3+json",
@@ -523,10 +523,13 @@
         "previews": []
       },
       "request": {},
-      "url": "/repos/{owner}/{repo}/git/ref/{ref}",
-      "owner": "gr2m",
-      "repo": "pull-request-test",
-      "ref": "heads/update-existing-pull-request"
+      "url": "/graphql",
+      "query": "\n    query ($owner: String!, $repo: String!, $head: String!) {\n      repository(name: $repo, owner: $owner) {\n        ref(qualifiedName: $head) {\n          associatedPullRequests(first: 1, states: OPEN) {\n            edges {\n              node {\n                id\n                number\n                url\n              }\n            }\n          }\n        }\n      }\n    }",
+      "variables": {
+        "owner": "gr2m",
+        "repo": "pull-request-test",
+        "head": "update-existing-pull-request"
+      }
     },
     "response": {
       "status": 200,
@@ -565,140 +568,22 @@
         "x-xss-protection": "0"
       },
       "data": {
-        "ref": "refs/heads/update-existing-pull-request",
-        "node_id": "MDM6UmVmMTYwOTg3NDkyOnJlZnMvaGVhZHMvdXBkYXRlLWV4aXN0aW5nLXB1bGwtcmVxdWVzdA==",
-        "url": "https://api.github.com/repos/gr2m/pull-request-test/git/refs/heads/update-existing-pull-request",
-        "object": {
-          "sha": "1c2697d5b02dbe6f6c909e7628273ba2ac45ca63",
-          "type": "commit",
-          "url": "https://api.github.com/repos/gr2m/pull-request-test/git/commits/1c2697d5b02dbe6f6c909e7628273ba2ac45ca63"
-        }
-      }
-    }
-  },
-  {
-    "request": {
-      "method": "GET",
-      "baseUrl": "https://api.github.com",
-      "headers": {
-        "accept": "application/vnd.github.v3+json",
-        "user-agent": "octokit-core.js/3.2.5 Node.js/18.3.0 (darwin; arm64)"
-      },
-      "mediaType": {
-        "format": "",
-        "previews": []
-      },
-      "request": {},
-      "url": "/search/issues",
-      "q": "head:update-existing-pull-request type:pr is:open repo:gr2m/pull-request-test"
-    },
-    "response": {
-      "status": 200,
-      "url": "https://api.github.com/search/issues?q=head%3Aupdate-existing-pull-request%20type%3Apr%20is%3Aopen%20repo%3Agr2m%2Fpull-request-test",
-      "headers": {
-        "access-control-allow-origin": "*",
-        "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset",
-        "cache-control": "no-cache",
-        "connection": "close",
-        "content-encoding": "gzip",
-        "content-security-policy": "default-src 'none'",
-        "content-type": "application/json; charset=utf-8",
-        "date": "Tue, 28 Jun 2022 10:54:29 GMT",
-        "github-authentication-token-expiration": "2022-08-24 23:46:54 UTC",
-        "referrer-policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
-        "server": "GitHub.com",
-        "strict-transport-security": "max-age=31536000; includeSubdomains; preload",
-        "transfer-encoding": "chunked",
-        "vary": "Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept, X-Requested-With",
-        "x-accepted-oauth-scopes": "",
-        "x-content-type-options": "nosniff",
-        "x-frame-options": "deny",
-        "x-github-api-version-selected": "",
-        "x-github-api-version-selected-reason": "unavailable",
-        "x-github-media-type": "github.v3; format=json",
-        "x-github-request-id": "DA6D:301F:D8BB51:E974CA:62BADDE5",
-        "x-oauth-scopes": "notifications, repo, workflow, write:org",
-        "x-ratelimit-limit": "30",
-        "x-ratelimit-remaining": "29",
-        "x-ratelimit-reset": "1656413729",
-        "x-ratelimit-resource": "search",
-        "x-ratelimit-used": "1",
-        "x-xss-protection": "0"
-      },
-      "data": {
-        "total_count": 1,
-        "incomplete_results": false,
-        "items": [
-          {
-            "url": "https://api.github.com/repos/gr2m/pull-request-test/issues/100",
-            "repository_url": "https://api.github.com/repos/gr2m/pull-request-test",
-            "labels_url": "https://api.github.com/repos/gr2m/pull-request-test/issues/100/labels{/name}",
-            "comments_url": "https://api.github.com/repos/gr2m/pull-request-test/issues/100/comments",
-            "events_url": "https://api.github.com/repos/gr2m/pull-request-test/issues/100/events",
-            "html_url": "https://github.com/gr2m/pull-request-test/pull/100",
-            "id": 1286621059,
-            "node_id": "PR_kwDOCZh5ZM46dY52",
-            "number": 100,
-            "title": "One comes, one goes",
-            "user": {
-              "login": "gr2m",
-              "id": 39992,
-              "node_id": "MDQ6VXNlcjM5OTky",
-              "avatar_url": "https://avatars.githubusercontent.com/u/39992?v=4",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/gr2m",
-              "html_url": "https://github.com/gr2m",
-              "followers_url": "https://api.github.com/users/gr2m/followers",
-              "following_url": "https://api.github.com/users/gr2m/following{/other_user}",
-              "gists_url": "https://api.github.com/users/gr2m/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/gr2m/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/gr2m/subscriptions",
-              "organizations_url": "https://api.github.com/users/gr2m/orgs",
-              "repos_url": "https://api.github.com/users/gr2m/repos",
-              "events_url": "https://api.github.com/users/gr2m/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/gr2m/received_events",
-              "type": "User",
-              "site_admin": true
-            },
-            "labels": [],
-            "state": "open",
-            "locked": false,
-            "assignee": null,
-            "assignees": [],
-            "milestone": null,
-            "comments": 0,
-            "created_at": "2022-06-28T00:55:54Z",
-            "updated_at": "2022-06-28T00:55:54Z",
-            "closed_at": null,
-            "author_association": "OWNER",
-            "active_lock_reason": null,
-            "draft": false,
-            "pull_request": {
-              "url": "https://api.github.com/repos/gr2m/pull-request-test/pulls/100",
-              "html_url": "https://github.com/gr2m/pull-request-test/pull/100",
-              "diff_url": "https://github.com/gr2m/pull-request-test/pull/100.diff",
-              "patch_url": "https://github.com/gr2m/pull-request-test/pull/100.patch",
-              "merged_at": null
-            },
-            "body": "because",
-            "reactions": {
-              "url": "https://api.github.com/repos/gr2m/pull-request-test/issues/100/reactions",
-              "total_count": 0,
-              "+1": 0,
-              "-1": 0,
-              "laugh": 0,
-              "hooray": 0,
-              "confused": 0,
-              "heart": 0,
-              "rocket": 0,
-              "eyes": 0
-            },
-            "timeline_url": "https://api.github.com/repos/gr2m/pull-request-test/issues/100/timeline",
-            "performed_via_github_app": null,
-            "state_reason": null,
-            "score": 1
+        "data": {
+          "repository": {
+            "ref": {
+              "associatedPullRequests": {
+                "edges": [
+                  {
+                    "node": {
+                      "url": "https://github.com/gr2m/pull-request-test/pull/100",
+                      "number": 100
+                    }
+                  }
+                ]
+              }
+            }
           }
-        ]
+        }
       }
     }
   },

--- a/test/fixtures/update-from-installation.json
+++ b/test/fixtures/update-from-installation.json
@@ -492,7 +492,7 @@
   },
   {
     "request": {
-      "method": "GET",
+      "method": "POST",
       "baseUrl": "https://api.github.com",
       "headers": {
         "accept": "application/vnd.github.v3+json",
@@ -503,13 +503,16 @@
         "previews": []
       },
       "request": {},
-      "url": "/repos/{owner}/{repo}/git/ref/{ref}",
-      "owner": "gr2m",
-      "repo": "pull-request-test",
-      "ref": "heads/update-from-installation"
+      "url": "/graphql",
+      "query": "\n    query ($owner: String!, $repo: String!, $head: String!) {\n      repository(name: $repo, owner: $owner) {\n        ref(qualifiedName: $head) {\n          associatedPullRequests(first: 1, states: OPEN) {\n            edges {\n              node {\n                id\n                number\n                url\n              }\n            }\n          }\n        }\n      }\n    }",
+      "variables": {
+        "owner": "gr2m",
+        "repo": "pull-request-test",
+        "head": "update-from-installation"
+      }
     },
     "response": {
-      "status": 404,
+      "status": 200,
       "headers": {
         "access-control-allow-origin": "*",
         "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset",
@@ -536,8 +539,11 @@
         "x-xss-protection": "0"
       },
       "data": {
-        "error": "Not Found",
-        "documentation_url": "https://docs.github.com/rest/reference/git#get-a-reference"
+        "data": {
+          "repository": {
+            "ref": null
+          }
+        }
       }
     }
   },

--- a/test/fixtures/update-readme.json
+++ b/test/fixtures/update-readme.json
@@ -635,7 +635,7 @@
   },
   {
     "request": {
-      "method": "GET",
+      "method": "POST",
       "baseUrl": "https://api.github.com",
       "headers": {
         "accept": "application/vnd.github.v3+json",
@@ -646,13 +646,16 @@
         "previews": []
       },
       "request": {},
-      "url": "/repos/{owner}/{repo}/git/ref/{ref}",
-      "owner": "gr2m",
-      "repo": "pull-request-test",
-      "ref": "heads/uppercase-readme"
+      "url": "/graphql",
+      "query": "\n    query ($owner: String!, $repo: String!, $head: String!) {\n      repository(name: $repo, owner: $owner) {\n        ref(qualifiedName: $head) {\n          associatedPullRequests(first: 1, states: OPEN) {\n            edges {\n              node {\n                id\n                number\n                url\n              }\n            }\n          }\n        }\n      }\n    }",
+      "variables": {
+        "owner": "gr2m",
+        "repo": "pull-request-test",
+        "head": "uppercase-readme"
+      }
     },
     "response": {
-      "status": 404,
+      "status": 200,
       "headers": {
         "access-control-allow-origin": "*",
         "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset",
@@ -684,8 +687,11 @@
         "x-xss-protection": "0"
       },
       "data": {
-        "error": "Not Found",
-        "documentation_url": "https://docs.github.com/rest/reference/git#get-a-reference"
+        "data": {
+          "repository": {
+            "ref": null
+          }
+        }
       }
     }
   },

--- a/test/fixtures/use-fork-blob.json
+++ b/test/fixtures/use-fork-blob.json
@@ -893,7 +893,7 @@
   },
   {
     "request": {
-      "method": "GET",
+      "method": "POST",
       "baseUrl": "https://api.github.com",
       "headers": {
         "accept": "application/vnd.github.v3+json",
@@ -904,13 +904,16 @@
         "previews": []
       },
       "request": {},
-      "url": "/repos/{owner}/{repo}/git/ref/{ref}",
-      "owner": "gr2m-test",
-      "repo": "pull-request-test",
-      "ref": "heads/test-branch-rlbes"
+      "url": "/graphql",
+      "query": "\n    query ($owner: String!, $repo: String!, $head: String!) {\n      repository(name: $repo, owner: $owner) {\n        ref(qualifiedName: $head) {\n          associatedPullRequests(first: 1, states: OPEN) {\n            edges {\n              node {\n                id\n                number\n                url\n              }\n            }\n          }\n        }\n      }\n    }",
+      "variables": {
+        "owner": "gr2m",
+        "repo": "pull-request-test",
+        "head": "test-branch-rlbes"
+      }
     },
     "response": {
-      "status": 404,
+      "status": 200,
       "headers": {
         "access-control-allow-origin": "*",
         "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset",
@@ -940,8 +943,11 @@
         "x-xss-protection": "0"
       },
       "data": {
-        "error": "Not Found",
-        "documentation_url": "https://docs.github.com/rest/reference/git#get-a-reference"
+        "data": {
+          "repository": {
+            "ref": null
+          }
+        }
       }
     }
   },

--- a/test/fixtures/use-fork.json
+++ b/test/fixtures/use-fork.json
@@ -841,7 +841,7 @@
   },
   {
     "request": {
-      "method": "GET",
+      "method": "POST",
       "baseUrl": "https://api.github.com",
       "headers": {
         "accept": "application/vnd.github.v3+json",
@@ -852,13 +852,16 @@
         "previews": []
       },
       "request": {},
-      "url": "/repos/{owner}/{repo}/git/ref/{ref}",
-      "owner": "gr2m-test",
-      "repo": "pull-request-test",
-      "ref": "heads/test-branch-rlbes"
+      "url": "/graphql",
+      "query": "\n    query ($owner: String!, $repo: String!, $head: String!) {\n      repository(name: $repo, owner: $owner) {\n        ref(qualifiedName: $head) {\n          associatedPullRequests(first: 1, states: OPEN) {\n            edges {\n              node {\n                id\n                number\n                url\n              }\n            }\n          }\n        }\n      }\n    }",
+      "variables": {
+        "owner": "gr2m",
+        "repo": "pull-request-test",
+        "head": "test-branch-rlbes"
+      }
     },
     "response": {
-      "status": 404,
+      "status": 200,
       "headers": {
         "access-control-allow-origin": "*",
         "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset",
@@ -888,8 +891,11 @@
         "x-xss-protection": "0"
       },
       "data": {
-        "error": "Not Found",
-        "documentation_url": "https://docs.github.com/rest/reference/git#get-a-reference"
+        "data": {
+          "repository": {
+            "ref": null
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
This PR uses graphql call instead of rest API v3 to get the existing branch and pull request info. This avoids 422 status code for search requests on private/internal repositories.

Discussion on 422 status code more here: https://github.com/orgs/community/discussions/24572