### PR TITLE
feat: add `signature` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ octokit
           email: "Committer.LastName@acme.com",
           date: new Date().toISOString(), // must be ISO date string
         },
+        /* optional: if not passed, commit won't be signed*/
+        signature: async function (commitPayload) {
+          // import { createSignature } from 'github-api-signature'
+          //
+          // return createSignature(
+          //   commitPayload,
+          //   privateKey,
+          //   passphrase
+          // );
+        },
       },
     ],
   })

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export type Changes = {
   commit: string;
   committer?: Committer;
   author?: Author | undefined;
+  signature?: SignatureFunction | undefined;
 };
 
 // https://developer.github.com/v3/git/blobs/#parameters
@@ -34,6 +35,8 @@ export type File = {
   encoding: "utf-8" | "base64";
   mode?: string;
 };
+
+export type SignatureFunction = (commitPayload: CommitPayload) => string;
 
 export type UpdateFunctionFile =
   | {
@@ -71,4 +74,12 @@ export type Author = {
   name: string;
   email: string;
   date?: string;
+};
+
+export type CommitPayload = {
+  message: string;
+  tree: string;
+  parents: string[];
+  author?: Author;
+  committer?: Committer;
 };

--- a/test/create-commits-with-author-and-committer.test.ts
+++ b/test/create-commits-with-author-and-committer.test.ts
@@ -27,6 +27,12 @@ test("author and committer", async () => {
     ).toEqual(`${options.method} ${options.url}`);
 
     Object.keys(params).forEach((paramName) => {
+      if (paramName === "signature") {
+        expect(currentFixtures.request.verification.signature).toStrictEqual(
+          "my-signature"
+        );
+        return;
+      }
       expect(currentFixtures.request[paramName]).toStrictEqual(
         params[paramName]
       );
@@ -76,6 +82,7 @@ test("author and committer", async () => {
           email: "Committer.Smith@acme.com",
           date: "2022-12-06T19:58:39.672Z",
         },
+        signature: () => "my-signature",
         commit: "Make a fix",
       },
     ],

--- a/test/fixtures/create-commits-with-author-and-committer.json
+++ b/test/fixtures/create-commits-with-author-and-committer.json
@@ -1839,6 +1839,12 @@
           "email": "Committer.Smith@acme.com",
           "date": "2022-12-06T19:58:39.672Z"
         },
+        "verification": {
+          "verified": false,
+          "reason": "signed",
+          "signature": "my-signature",
+          "payload": null
+        },
         "tree": "342b3bfaaa972fe97be3e14d3665f9649327913b",
         "parents": [
           "61165f91e197e5759eff4c7b27bb87ef2c200bf2"


### PR DESCRIPTION
Fixes #118 by introducing a new property `signature`. 

I didn't want to introduce another dependency to `octokit-plugin-create-pull-request`. Therefore `signature` is a function which allows the caller to implement the actual commit signing however it suits best to them. 