### PR TITLE
docs(README): fix syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ octokit
             // do nothing if it does not exist
             if (!exists) return null;
 
-            const content = Buffer.from(content, encoding)
+            const fileContent = Buffer.from(content, encoding)
               .toString("utf-8")
               .toUpperCase();
 
-            if (content.includes("octomania")) {
+            if (fileContent.includes("octomania")) {
               // delete file
               return DELETE_FILE;
             }

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ octokit
             // do nothing if it does not exist
             if (!exists) return null;
 
-            const fileContent = Buffer.from(content, encoding)
-              .toString("utf-8")
-              .toUpperCase();
+            const fileContent = Buffer.from(content, encoding).toString(
+              "utf-8"
+            );
 
             if (fileContent.includes("octomania")) {
               // delete file


### PR DESCRIPTION
Copy&pasting the example code throws `Identifier 'content' has already been declared`. Also the code example wasn't working as intended because of the uppercasing and therefore the condition does fail all the time 